### PR TITLE
Added support for Metric alerts (#91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The following resources are used by this module:
 - [azurerm_management_lock.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
 - [azurerm_monitor_diagnostic_setting.cdn_endpoint_diag](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) (resource)
 - [azurerm_monitor_diagnostic_setting.front_door_diag](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) (resource)
+- [azurerm_monitor_metric_alert.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) (resource)
 - [azurerm_role_assignment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
 - [modtm_telemetry.telemetry](https://registry.terraform.io/providers/azure/modtm/latest/docs/resources/telemetry) (resource)
 - [random_uuid.telemetry](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) (resource)
@@ -1723,6 +1724,140 @@ object({
     system_assigned            = optional(bool, false)
     user_assigned_resource_ids = optional(set(string), [])
   })
+```
+
+Default: `{}`
+
+### <a name="input_metric_alerts"></a> [metric\_alerts](#input\_metric\_alerts)
+
+Description:   Manages a map of Metric Alerts to create on the cdn/Front door profile.
+
+  - `name` - (Required) The name of the metric alert.Changing this forces a new resource to be created.
+  - `auto_mitigate` - (Optional) If set to true, automatically mitigates the alert. Defaults to `true`.
+  - `description` - (Optional) The description of the metric alert.
+  - `enabled` - (Optional) If set to true, enables the metric alert. Defaults to `true`.
+  - `frequency` - (Optional) The frequency of the metric alert. Possible values are `PT1M`, `PT5M`, `PT15M`, `PT30M` and `PT1H`. Defaults to `PT1M`.
+  - `severity` - (Optional) The severity of the metric alert. Possible values are `0`, `1`, `2`, `3` and `4`. Defaults to `3`.
+  - `target_resource_type` - (Optional) The type of the target resource. This is Required when using a Subscription as scope, a Resource Group as scope or Multiple Scopes.
+  - `target_resource_location` - (Optional) The location of the target resource. This is Required when using a Subscription as scope, a Resource Group as scope or Multiple Scopes.
+  - `window_size` - (Optional) The period of time that is used to monitor alert activity, represented in ISO 8601 duration format. This value must be greater than `frequency`. Possible values are `PT1M`, `PT5M`, `PT15M`, `PT30M`, `PT1H`, `PT6H`, `PT12H` and `P1D`. Defaults to `PT5M`.
+  - `tags` - (Optional) A map of tags to assign to the metric alert.
+  - `actions` - (Optional) A list of actions blocks as defined below:-
+    - `action_group_id` - (Required) The ID of the action group, can be sourced from the `azurerm_monitor_action_group` resource.
+    - `webhook_properties` - (Optional) A map of webhook properties.
+  - `criterias` - (Optional) A list of criterias blocks as defined below:-
+    - `metric_namespace` - (Required) The namespace of the metric.
+    - `metric_name` - (Required) The name of the metric.
+    - `aggregation` - (Required) The statistic that runs over the metric values. Possible values are `Average`, `Count`, `Minimum`, `Maximum` and `Total`.
+    - `operator` - (Required) The operator of the metric. Possible values are `Equals`, `GreaterThan`, `GreaterThanOrEqual`, `LessThan` and `LessThanOrEqual`.
+    - `threshold` - (Required) The criteria threshold value that activates the alert.
+    - `skip_metric_validation` - (Optional) If set to true, skips the validation of the metric. Defaults to `false`.
+    - `dimensions` - (Optional) A list of dimensions blocks as defined below:-
+      - `name` - (Required) The name of the dimension.
+      - `operator` - (Required) The operator of the dimension. Possible values are `Include`, `Exclude` and `StartsWith`.
+      - `values` - (Required) The values of the dimension.
+  - `dynamic_criterias` - (Optional) A list of dynamic\_criteria blocks as defined below:-
+    - `alert_sensitivity` - (Required) The sensitivity of the alert. Possible values are `Low`, `Medium` and `High`.
+    - `aggregation` - (Required) The aggregation type of the metric. Possible values are `Average`, `Count`, `Minimum`, `Maximum` and `Total`.
+    - `operator` - (Required) The operator of the metric. Possible values are `GreaterThan`, `LessThan`, `GreaterOrLessThan`.
+    - `dimension` - (Optional) A list of dimension blocks as defined below:-
+      - `name` - (Required) The name of the dimension.
+      - `operator` - (Required) The operator of the dimension. Possible values are `Include`, `Exclude` and `StartsWith`.
+      - `values` - (Required) The values of the dimension.
+    - `evaluation_failure_count` - (Optional) The number of consecutive breaches of the threshold required to trigger an alert. Defaults to `4`.
+    - `evaluation_total_count` - (Optional) The number of consecutive evaluations required to trigger an alert.The lookback time window is calculated based on the aggregation granularity (window\_size) and the selected number of aggregated points. Defaults to `4`.
+    - `ignore_data_before` - (Optional) The ISO8601 date from which to start learning the metric historical data and calculate the dynamic thresholds.
+    - `metric_namespace` - (Required) The namespace of the metric.
+    - `metric_name` - (Required) The name of the metric.
+    - `skip_metric_validation` - (Optional) If set to true, skips the validation of the metric. Defaults to `false`.
+  - `application_insights_web_test_location_availability_criterias` - (Optional) A list of application\_insights\_web\_test\_location\_availability\_criteria blocks as defined below:-
+    - `component_id` - (Required) The ID of the Application Insights component.
+    - `failed_location_count` - (Required) The number of failed locations.
+    - `web_test_id` - (Required) The ID of the web test.
+
+  Example Input:
+
+  ```terraform  
+
+  metric_alerts = {
+    alert1 = {
+      name                = "1st criterion"
+      description         = "Action will be triggered when ByteHitRatio is less than 90."
+      enabled             = false
+      frequency           = "PT5M"
+      severity            = 2
+      target_resource_type = "Microsoft.Cdn/profiles"
+      window_size         = "PT30M"
+      tags                = {
+        environment = "AVM-Test"
+      }
+      criterias = [{
+        metric_namespace = "Microsoft.Cdn/profiles"
+        metric_name      = "ByteHitRatio"
+        aggregation      = "Average"
+        operator         = "LessThan"
+        threshold        = 90
+      }]
+      actions = [{
+        action_group_id = azurerm_monitor_action_group.example.id
+      }]
+    }
+
+```
+
+Type:
+
+```hcl
+map(object({
+    name = string
+    criterias = optional(list(object({
+      metric_namespace       = string
+      metric_name            = string
+      aggregation            = string # Possible values are Average, Count, Minimum, Maximum and Total
+      operator               = string # Possible values are Equals, GreaterThan, GreaterThanOrEqual, LessThan and LessThanOrEqual
+      threshold              = number
+      skip_metric_validation = optional(bool, false)
+      dimensions = optional(list(object({
+        name     = string
+        operator = string
+        values   = list(string)
+      })))
+    })), [])
+    actions = optional(list(object({
+      action_group_id    = string
+      webhook_properties = optional(map(string))
+    })), [])
+    dynamic_criterias = optional(list(object({
+      alert_sensitivity = string # Possible values are 'Low', 'Medium' and 'High'
+      aggregation       = string # Possible values are 'Average', 'Count', 'Minimum', 'Maximum' and 'Total'.
+      operator          = string # Possible values are 'GreaterThan', 'LessThan', 'GreaterOrLessThan'.
+      dimension = optional(list(object({
+        name     = string
+        operator = string # Possible values are 'Include', 'Exclude' and 'StartsWith'.
+        values   = list(string)
+      })), [])
+      evaluation_failure_count = optional(number, 4)
+      evaluation_total_count   = optional(number, 4)
+      ignore_data_before       = optional(string) # The ISO8601 date from which to start learning the metric historical data and calculate the dynamic thresholds.
+      metric_namespace         = string
+      metric_name              = string
+      skip_metric_validation   = optional(bool, false)
+    })), [])
+    application_insights_web_test_location_availability_criterias = optional(list(object({
+      component_id          = string
+      failed_location_count = number
+      web_test_id           = string
+    })), [])
+    auto_mitigate            = optional(bool, true)
+    description              = optional(string)
+    enabled                  = optional(bool, true)
+    frequency                = optional(string, "PT1M") # Possible values are PT1M, PT5M, PT15M, PT30M and PT1H
+    severity                 = optional(number, 3)      # Possible values are 0, 1, 2, 3 and 4
+    target_resource_type     = optional(string)         # This is Required when using a Subscription as scope, a Resource Group as scope or Multiple Scopes.
+    target_resource_location = optional(string)         # This is Required when using a Subscription as scope, a Resource Group as scope or Multiple Scopes.
+    window_size              = optional(string, "PT5M") # This value must be greater than 'frequency'. Possible values are PT1M, PT5M, PT15M, PT30M, PT1H, PT6H, PT12H and P1D
+    tags                     = optional(map(string))
+  }))
 ```
 
 Default: `{}`

--- a/examples/afd_interfaces/README.md
+++ b/examples/afd_interfaces/README.md
@@ -81,6 +81,19 @@ resource "azurerm_user_assigned_identity" "identity_for_keyvault" {
   resource_group_name = azurerm_resource_group.this.name
 }
 
+# Creating an action group for metric alerts
+resource "azurerm_monitor_action_group" "example" {
+  name                = "CriticalAlertsAction"
+  resource_group_name = azurerm_resource_group.this.name
+  short_name          = "p0action"
+
+  email_receiver {
+    email_address           = "devops@contoso.com"
+    name                    = "sendtodevops"
+    use_common_alert_schema = true
+  }
+}
+
 /* This is the module call that shows how to add interfaces for waf alignment
 Locks
 Tags
@@ -271,6 +284,118 @@ module "azurerm_cdn_frontdoor_profile" {
     }
   }
 
+  # Below example represents the recommended metric alerts for CDN profile as per [Azure Monitor baseline Alerts](https://azure.github.io/azure-monitor-baseline-alerts/services/Cdn/profiles/)
+  metric_alerts = {
+    alert1 = {
+      name                 = "1st criterion"
+      description          = "Action will be triggered when ByteHitRatio is less than 90."
+      enabled              = false
+      frequency            = "PT5M"
+      severity             = 2
+      target_resource_type = "Microsoft.Cdn/profiles"
+      window_size          = "PT30M"
+      criterias = [{
+        metric_namespace = "Microsoft.Cdn/profiles"
+        metric_name      = "ByteHitRatio"
+        aggregation      = "Average"
+        operator         = "LessThan"
+        threshold        = 90
+      }]
+      actions = [{
+        action_group_id = azurerm_monitor_action_group.example.id
+      }]
+    }
+
+    alert2 = {
+      name                 = "2nd criterion"
+      description          = "Action will be triggered when OriginHealthPercentage is less than 90."
+      enabled              = false
+      frequency            = "PT1M"
+      severity             = 2
+      target_resource_type = "Microsoft.Cdn/profiles"
+      window_size          = "PT5M"
+      criterias = [{
+        metric_namespace = "Microsoft.Cdn/profiles"
+        metric_name      = "OriginHealthPercentage"
+        aggregation      = "Average"
+        operator         = "LessThanOrEqual"
+        threshold        = 90
+        dimensions = [{
+          name     = "Origingroup"
+          operator = "Include"
+          values   = ["render"]
+        }]
+      }]
+      actions = [{
+        action_group_id = azurerm_monitor_action_group.example.id
+      }]
+    }
+
+    alert3 = {
+      name                 = "3rd criterion"
+      description          = "Action will be triggered when Percentage5XX is greater than 10."
+      enabled              = false
+      frequency            = "PT1M"
+      severity             = 2
+      target_resource_type = "Microsoft.Cdn/profiles"
+      window_size          = "PT5M"
+      criterias = [{
+        metric_namespace = "Microsoft.Cdn/profiles"
+        metric_name      = "Percentage5XX"
+        aggregation      = "Average"
+        operator         = "GreaterThan"
+        threshold        = 10
+      }]
+      actions = [{
+        action_group_id = azurerm_monitor_action_group.example.id
+      }]
+    }
+
+    alert4 = {
+      name                 = "4th criterion"
+      description          = "Action will be triggered when RequestCount is greater than 1000."
+      enabled              = false
+      frequency            = "PT1M"
+      severity             = 3
+      target_resource_type = "Microsoft.Cdn/profiles"
+      window_size          = "PT5M"
+      # Provide tags value if you dont want the default tags of CDN profile to be inherited
+      tags = {
+        environment = "AVM-Test"
+      }
+      criterias = [{
+        metric_namespace = "Microsoft.Cdn/profiles"
+        metric_name      = "RequestCount"
+        aggregation      = "Total"
+        operator         = "GreaterThan"
+        threshold        = 1000
+      }]
+      actions = [{
+        action_group_id = azurerm_monitor_action_group.example.id
+      }]
+    }
+
+    alert5 = {
+      name                 = "5th criterion"
+      description          = "Action will be triggered when TotalLatency is greater than 100."
+      enabled              = false
+      frequency            = "PT1M"
+      severity             = 2
+      target_resource_type = "Microsoft.Cdn/profiles"
+      window_size          = "PT5M"
+      criterias = [{
+        metric_namespace = "Microsoft.Cdn/profiles"
+        metric_name      = "TotalLatency"
+        aggregation      = "Average"
+        operator         = "GreaterThan"
+        threshold        = 100
+      }]
+      actions = [{
+        action_group_id = azurerm_monitor_action_group.example.id
+      }]
+    }
+  }
+
   diagnostic_settings = {
     workspaceandstorage_diag = {
       name                           = "workspaceandstorage_diag"
@@ -346,6 +471,7 @@ The following resources are used by this module:
 - [azurerm_eventhub_namespace.eventhub_namespace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/eventhub_namespace) (resource)
 - [azurerm_eventhub_namespace_authorization_rule.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/eventhub_namespace_authorization_rule) (resource)
 - [azurerm_log_analytics_workspace.workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) (resource)
+- [azurerm_monitor_action_group.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) (resource)
 - [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
 - [azurerm_storage_account.storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) (resource)
 - [azurerm_user_assigned_identity.identity_for_keyvault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) (resource)

--- a/examples/afd_security_policies/README.md
+++ b/examples/afd_security_policies/README.md
@@ -43,6 +43,9 @@ module "azurerm_cdn_frontdoor_profile" {
   location            = azurerm_resource_group.this.location
   sku                 = "Premium_AzureFrontDoor"
   resource_group_name = azurerm_resource_group.this.name
+  tags = {
+    environment = "avm-demo"
+  }
   front_door_origin_groups = {
     og1_key = {
       name = "og1"

--- a/examples/afd_security_policies/main.tf
+++ b/examples/afd_security_policies/main.tf
@@ -37,6 +37,9 @@ module "azurerm_cdn_frontdoor_profile" {
   location            = azurerm_resource_group.this.location
   sku                 = "Premium_AzureFrontDoor"
   resource_group_name = azurerm_resource_group.this.name
+  tags = {
+    environment = "avm-demo"
+  }
   front_door_origin_groups = {
     og1_key = {
       name = "og1"

--- a/examples/cdn_default_microsoft_with_custom_domain/README.md
+++ b/examples/cdn_default_microsoft_with_custom_domain/README.md
@@ -49,7 +49,7 @@ resource "azurerm_storage_account" "storage" {
 module "azurerm_cdn_profile" {
   source = "../../"
   tags = {
-    environment = "avm-demo"
+    environment = "avm-CDN-demo"
   }
   enable_telemetry    = var.enable_telemetry
   name                = module.naming.cdn_profile.name_unique

--- a/examples/cdn_default_microsoft_with_custom_domain/main.tf
+++ b/examples/cdn_default_microsoft_with_custom_domain/main.tf
@@ -43,7 +43,7 @@ resource "azurerm_storage_account" "storage" {
 module "azurerm_cdn_profile" {
   source = "../../"
   tags = {
-    environment = "avm-demo"
+    environment = "avm-CDN-demo"
   }
   enable_telemetry    = var.enable_telemetry
   name                = module.naming.cdn_profile.name_unique

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -31,11 +31,14 @@ resource "azurerm_resource_group" "this" {
 
 # This is the module call
 module "azurerm_cdn_frontdoor_profile" {
-  source              = "../../"
-  enable_telemetry    = var.enable_telemetry
-  name                = module.naming.cdn_profile.name_unique
-  location            = azurerm_resource_group.this.location
-  sku                 = "Standard_AzureFrontDoor"
+  source           = "../../"
+  enable_telemetry = var.enable_telemetry
+  name             = module.naming.cdn_profile.name_unique
+  location         = azurerm_resource_group.this.location
+  sku              = "Standard_AzureFrontDoor"
+  tags = {
+    environment = "avm-demo"
+  }
   resource_group_name = azurerm_resource_group.this.name
   front_door_origin_groups = {
     og1_key = {
@@ -105,9 +108,6 @@ module "azurerm_cdn_frontdoor_profile" {
     }
     ep2_key = {
       name = "ep2-${module.naming.cdn_endpoint.name_unique}"
-      tags = {
-        environment = "avm-test"
-      }
     }
   }
   front_door_rule_sets = ["ruleset1", "ruleset2"]

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -25,11 +25,14 @@ resource "azurerm_resource_group" "this" {
 
 # This is the module call
 module "azurerm_cdn_frontdoor_profile" {
-  source              = "../../"
-  enable_telemetry    = var.enable_telemetry
-  name                = module.naming.cdn_profile.name_unique
-  location            = azurerm_resource_group.this.location
-  sku                 = "Standard_AzureFrontDoor"
+  source           = "../../"
+  enable_telemetry = var.enable_telemetry
+  name             = module.naming.cdn_profile.name_unique
+  location         = azurerm_resource_group.this.location
+  sku              = "Standard_AzureFrontDoor"
+  tags = {
+    environment = "avm-demo"
+  }
   resource_group_name = azurerm_resource_group.this.name
   front_door_origin_groups = {
     og1_key = {
@@ -99,9 +102,6 @@ module "azurerm_cdn_frontdoor_profile" {
     }
     ep2_key = {
       name = "ep2-${module.naming.cdn_endpoint.name_unique}"
-      tags = {
-        environment = "avm-test"
-      }
     }
   }
   front_door_rule_sets = ["ruleset1", "ruleset2"]

--- a/main.cdn_endpoints.tf
+++ b/main.cdn_endpoints.tf
@@ -13,7 +13,7 @@ resource "azurerm_cdn_endpoint" "endpoints" {
   origin_path                   = each.value.origin_path
   probe_path                    = each.value.probe_path
   querystring_caching_behaviour = each.value.querystring_caching_behaviour
-  tags                          = each.value.tags
+  tags                          = each.value.tags != null ? each.value.tags : var.tags
 
   dynamic "origin" {
     for_each = each.value.origins

--- a/main.cdn_frontdoor_endpoints.tf
+++ b/main.cdn_frontdoor_endpoints.tf
@@ -4,7 +4,7 @@ resource "azurerm_cdn_frontdoor_endpoint" "endpoints" {
   cdn_frontdoor_profile_id = azapi_resource.front_door_profile.id
   name                     = each.value.name
   enabled                  = each.value.enabled
-  tags                     = each.value.tags
+  tags                     = each.value.tags != null ? each.value.tags : var.tags
 }
 
 resource "azurerm_cdn_frontdoor_route" "routes" {

--- a/main.cdn_frontdoor_wafandsecuritypolicy.tf
+++ b/main.cdn_frontdoor_wafandsecuritypolicy.tf
@@ -1,6 +1,3 @@
-
-
-
 resource "azurerm_cdn_frontdoor_firewall_policy" "wafs" {
   for_each = var.front_door_firewall_policies != null ? var.front_door_firewall_policies : {}
 
@@ -12,7 +9,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "wafs" {
   custom_block_response_status_code = each.value.custom_block_response_status_code
   enabled                           = each.value.enabled
   redirect_url                      = each.value.redirect_url
-  tags                              = each.value.tags
+  tags                              = each.value.tags != null ? each.value.tags : var.tags
 
   dynamic "custom_rule" {
     for_each = try(each.value.custom_rules, null)

--- a/main.interfaces.tf
+++ b/main.interfaces.tf
@@ -113,3 +113,81 @@ resource "azurerm_management_lock" "this" {
   depends_on = [azapi_resource.front_door_profile]
 }
 
+# metric alerts
+resource "azurerm_monitor_metric_alert" "this" {
+  for_each = var.metric_alerts != null ? var.metric_alerts : {}
+
+  name                     = each.value.name
+  resource_group_name      = data.azurerm_resource_group.rg.name
+  scopes                   = [azapi_resource.front_door_profile.id]
+  auto_mitigate            = each.value.auto_mitigate
+  description              = each.value.description
+  enabled                  = each.value.enabled
+  frequency                = each.value.frequency
+  severity                 = each.value.severity
+  tags                     = each.value.tags != null ? each.value.tags : var.tags
+  target_resource_location = each.value.target_resource_location
+  target_resource_type     = each.value.target_resource_type
+  window_size              = each.value.window_size
+
+  dynamic "action" {
+    for_each = each.value.actions != null ? each.value.actions : []
+
+    content {
+      action_group_id    = action.value.action_group_id
+      webhook_properties = action.value.webhook_properties
+    }
+  }
+  dynamic "application_insights_web_test_location_availability_criteria" {
+    for_each = each.value.application_insights_web_test_location_availability_criterias != null ? each.value.application_insights_web_test_location_availability_criterias : []
+
+    content {
+      component_id          = application_insights_web_test_location_availability_criteria.value.component_id
+      failed_location_count = application_insights_web_test_location_availability_criteria.value.failed_location_count
+      web_test_id           = application_insights_web_test_location_availability_criteria.value.web_test_id
+    }
+  }
+  dynamic "criteria" {
+    for_each = try(each.value.criterias, [])
+
+    content {
+      aggregation            = criteria.value.aggregation
+      metric_name            = criteria.value.metric_name
+      metric_namespace       = criteria.value.metric_namespace
+      operator               = criteria.value.operator
+      threshold              = criteria.value.threshold
+      skip_metric_validation = criteria.value.skip_metric_validation
+
+      dynamic "dimension" {
+        for_each = criteria.value.dimensions != null ? criteria.value.dimensions : []
+
+        content {
+          name     = dimension.value.name
+          operator = dimension.value.operator
+          values   = dimension.value.values
+        }
+      }
+    }
+  }
+  dynamic "dynamic_criteria" {
+    for_each = each.value.dynamic_criterias != null ? each.value.dynamic_criterias : []
+
+    content {
+      aggregation              = dynamic_criteria.value.aggregation
+      alert_sensitivity        = dynamic_criteria.value.alert_sensitivity
+      metric_name              = dynamic_criteria.value.metric_name
+      metric_namespace         = dynamic_criteria.value.metric_namespace
+      operator                 = dynamic_criteria.value.operator
+      evaluation_failure_count = dynamic_criteria.value.evaluation_failure_count
+      evaluation_total_count   = dynamic_criteria.value.evaluation_total_count
+      ignore_data_before       = dynamic_criteria.value.ignore_data_before
+      skip_metric_validation   = dynamic_criteria.value.skip_metric_validation
+
+      dimension {
+        name     = dynamic_criteria.value.dimension.name
+        operator = dynamic_criteria.value.dimension.operator
+        values   = dynamic_criteria.value.dimension.values
+      }
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -2145,6 +2145,178 @@ variable "managed_identities" {
   nullable    = false
 }
 
+variable "metric_alerts" {
+  type = map(object({
+    name = string
+    criterias = optional(list(object({
+      metric_namespace       = string
+      metric_name            = string
+      aggregation            = string # Possible values are Average, Count, Minimum, Maximum and Total
+      operator               = string # Possible values are Equals, GreaterThan, GreaterThanOrEqual, LessThan and LessThanOrEqual
+      threshold              = number
+      skip_metric_validation = optional(bool, false)
+      dimensions = optional(list(object({
+        name     = string
+        operator = string
+        values   = list(string)
+      })))
+    })), [])
+    actions = optional(list(object({
+      action_group_id    = string
+      webhook_properties = optional(map(string))
+    })), [])
+    dynamic_criterias = optional(list(object({
+      alert_sensitivity = string # Possible values are 'Low', 'Medium' and 'High'
+      aggregation       = string # Possible values are 'Average', 'Count', 'Minimum', 'Maximum' and 'Total'.
+      operator          = string # Possible values are 'GreaterThan', 'LessThan', 'GreaterOrLessThan'.
+      dimension = optional(list(object({
+        name     = string
+        operator = string # Possible values are 'Include', 'Exclude' and 'StartsWith'.
+        values   = list(string)
+      })), [])
+      evaluation_failure_count = optional(number, 4)
+      evaluation_total_count   = optional(number, 4)
+      ignore_data_before       = optional(string) # The ISO8601 date from which to start learning the metric historical data and calculate the dynamic thresholds.
+      metric_namespace         = string
+      metric_name              = string
+      skip_metric_validation   = optional(bool, false)
+    })), [])
+    application_insights_web_test_location_availability_criterias = optional(list(object({
+      component_id          = string
+      failed_location_count = number
+      web_test_id           = string
+    })), [])
+    auto_mitigate            = optional(bool, true)
+    description              = optional(string)
+    enabled                  = optional(bool, true)
+    frequency                = optional(string, "PT1M") # Possible values are PT1M, PT5M, PT15M, PT30M and PT1H
+    severity                 = optional(number, 3)      # Possible values are 0, 1, 2, 3 and 4
+    target_resource_type     = optional(string)         # This is Required when using a Subscription as scope, a Resource Group as scope or Multiple Scopes.
+    target_resource_location = optional(string)         # This is Required when using a Subscription as scope, a Resource Group as scope or Multiple Scopes.
+    window_size              = optional(string, "PT5M") # This value must be greater than 'frequency'. Possible values are PT1M, PT5M, PT15M, PT30M, PT1H, PT6H, PT12H and P1D
+    tags                     = optional(map(string))
+  }))
+  default     = {}
+  description = <<DESCRIPTION
+  Manages a map of Metric Alerts to create on the cdn/Front door profile.
+
+  - `name` - (Required) The name of the metric alert.Changing this forces a new resource to be created.
+  - `auto_mitigate` - (Optional) If set to true, automatically mitigates the alert. Defaults to `true`.
+  - `description` - (Optional) The description of the metric alert.
+  - `enabled` - (Optional) If set to true, enables the metric alert. Defaults to `true`.
+  - `frequency` - (Optional) The frequency of the metric alert. Possible values are `PT1M`, `PT5M`, `PT15M`, `PT30M` and `PT1H`. Defaults to `PT1M`.
+  - `severity` - (Optional) The severity of the metric alert. Possible values are `0`, `1`, `2`, `3` and `4`. Defaults to `3`.
+  - `target_resource_type` - (Optional) The type of the target resource. This is Required when using a Subscription as scope, a Resource Group as scope or Multiple Scopes.
+  - `target_resource_location` - (Optional) The location of the target resource. This is Required when using a Subscription as scope, a Resource Group as scope or Multiple Scopes.
+  - `window_size` - (Optional) The period of time that is used to monitor alert activity, represented in ISO 8601 duration format. This value must be greater than `frequency`. Possible values are `PT1M`, `PT5M`, `PT15M`, `PT30M`, `PT1H`, `PT6H`, `PT12H` and `P1D`. Defaults to `PT5M`.
+  - `tags` - (Optional) A map of tags to assign to the metric alert.
+  - `actions` - (Optional) A list of actions blocks as defined below:-
+    - `action_group_id` - (Required) The ID of the action group, can be sourced from the `azurerm_monitor_action_group` resource.
+    - `webhook_properties` - (Optional) A map of webhook properties.
+  - `criterias` - (Optional) A list of criterias blocks as defined below:-
+    - `metric_namespace` - (Required) The namespace of the metric.
+    - `metric_name` - (Required) The name of the metric.
+    - `aggregation` - (Required) The statistic that runs over the metric values. Possible values are `Average`, `Count`, `Minimum`, `Maximum` and `Total`.
+    - `operator` - (Required) The operator of the metric. Possible values are `Equals`, `GreaterThan`, `GreaterThanOrEqual`, `LessThan` and `LessThanOrEqual`.
+    - `threshold` - (Required) The criteria threshold value that activates the alert.
+    - `skip_metric_validation` - (Optional) If set to true, skips the validation of the metric. Defaults to `false`.
+    - `dimensions` - (Optional) A list of dimensions blocks as defined below:-
+      - `name` - (Required) The name of the dimension.
+      - `operator` - (Required) The operator of the dimension. Possible values are `Include`, `Exclude` and `StartsWith`.
+      - `values` - (Required) The values of the dimension.
+  - `dynamic_criterias` - (Optional) A list of dynamic_criteria blocks as defined below:-
+    - `alert_sensitivity` - (Required) The sensitivity of the alert. Possible values are `Low`, `Medium` and `High`.
+    - `aggregation` - (Required) The aggregation type of the metric. Possible values are `Average`, `Count`, `Minimum`, `Maximum` and `Total`.
+    - `operator` - (Required) The operator of the metric. Possible values are `GreaterThan`, `LessThan`, `GreaterOrLessThan`.
+    - `dimension` - (Optional) A list of dimension blocks as defined below:-
+      - `name` - (Required) The name of the dimension.
+      - `operator` - (Required) The operator of the dimension. Possible values are `Include`, `Exclude` and `StartsWith`.
+      - `values` - (Required) The values of the dimension.
+    - `evaluation_failure_count` - (Optional) The number of consecutive breaches of the threshold required to trigger an alert. Defaults to `4`.
+    - `evaluation_total_count` - (Optional) The number of consecutive evaluations required to trigger an alert.The lookback time window is calculated based on the aggregation granularity (window_size) and the selected number of aggregated points. Defaults to `4`.
+    - `ignore_data_before` - (Optional) The ISO8601 date from which to start learning the metric historical data and calculate the dynamic thresholds.
+    - `metric_namespace` - (Required) The namespace of the metric.
+    - `metric_name` - (Required) The name of the metric.
+    - `skip_metric_validation` - (Optional) If set to true, skips the validation of the metric. Defaults to `false`.
+  - `application_insights_web_test_location_availability_criterias` - (Optional) A list of application_insights_web_test_location_availability_criteria blocks as defined below:-
+    - `component_id` - (Required) The ID of the Application Insights component.
+    - `failed_location_count` - (Required) The number of failed locations.
+    - `web_test_id` - (Required) The ID of the web test.
+
+  Example Input:
+
+  ```terraform  
+
+  metric_alerts = {
+    alert1 = {
+      name                = "1st criterion"
+      description         = "Action will be triggered when ByteHitRatio is less than 90."
+      enabled             = false
+      frequency           = "PT5M"
+      severity            = 2
+      target_resource_type = "Microsoft.Cdn/profiles"
+      window_size         = "PT30M"
+      tags                = {
+        environment = "AVM-Test"
+      }
+      criterias = [{
+        metric_namespace = "Microsoft.Cdn/profiles"
+        metric_name      = "ByteHitRatio"
+        aggregation      = "Average"
+        operator         = "LessThan"
+        threshold        = 90
+      }]
+      actions = [{
+        action_group_id = azurerm_monitor_action_group.example.id
+      }]
+    }
+
+  ```
+  DESCRIPTION
+  nullable    = false
+
+  validation {
+    condition     = alltrue([for _, v in var.metric_alerts : contains(["PT1M", "PT5M", "PT15M", "PT30M", "PT1H"], v.frequency)])
+    error_message = "The frequency must be either `PT1M`, `PT5M`, `PT15M`, `PT30M` or `PT1H`."
+  }
+  validation {
+    condition     = alltrue([for _, v in var.metric_alerts : contains(["PT1M", "PT5M", "PT15M", "PT30M", "PT1H", "PT6H", "PT12H", "P1D"], v.window_size)])
+    error_message = "The window_size must be either `PT1M`, `PT5M`, `PT15M`, `PT30M`, `PT1H`, `PT6H`, `PT12H` or `P1D`."
+  }
+  validation {
+    condition     = alltrue([for _, v in var.metric_alerts : contains([0, 1, 2, 3, 4], v.severity)])
+    error_message = "The severity must be either `0`, `1`, `2`, `3` or `4`."
+  }
+  validation {
+    condition     = alltrue([for _, v in var.metric_alerts : v.criterias != null ? alltrue([for c in v.criterias : contains(["Average", "Count", "Minimum", "Maximum", "Total"], c.aggregation)]) : true])
+    error_message = "Invalid aggregation value in criterias. Possible values are `Average`, `Count`, `Minimum`, `Maximum` and `Total`."
+  }
+  validation {
+    condition     = alltrue([for _, v in var.metric_alerts : v.criterias != null ? alltrue([for c in v.criterias : contains(["Equals", "GreaterThan", "GreaterThanOrEqual", "LessThan", "LessThanOrEqual"], c.operator)]) : true])
+    error_message = "Invalid operator value in criterias. Possible values are `Equals`, `GreaterThan`, `GreaterThanOrEqual`, `LessThan` and `LessThanOrEqual`."
+  }
+  validation {
+    condition     = alltrue([for _, v in var.metric_alerts : v.criterias != null ? alltrue([for c in v.criterias : c.dimensions != null ? alltrue([for d in c.dimensions : contains(["Include", "Exclude", "StartsWith"], d.operator)]) : true]) : true])
+    error_message = "Invalid operator value in dimensions. Possible values are `Include`, `Exclude` and `StartsWith`."
+  }
+  validation {
+    condition     = alltrue([for _, v in var.metric_alerts : v.dynamic_criterias != null ? alltrue([for dc in v.dynamic_criterias : contains(["Low", "Medium", "High"], dc.alert_sensitivity)]) : true])
+    error_message = "Invalid alert sensitivity value in dynamic_criterias. Possible values are `Low`, `Medium` and `High`."
+  }
+  validation {
+    condition     = alltrue([for _, v in var.metric_alerts : v.dynamic_criterias != null ? alltrue([for dc in v.dynamic_criterias : contains(["Average", "Count", "Minimum", "Maximum", "Total"], dc.aggregation)]) : true])
+    error_message = "Invalid aggregation value in dynamic_criterias. Possible values are `Average`, `Count`, `Minimum`, `Maximum` and `Total`."
+  }
+  validation {
+    condition     = alltrue([for _, v in var.metric_alerts : v.dynamic_criterias != null ? alltrue([for dc in v.dynamic_criterias : contains(["GreaterThan", "LessThan", "GreaterOrLessThan"], dc.operator)]) : true])
+    error_message = "Invalid operator value in dynamic_criterias. Possible values are `GreaterThan`, `LessThan`, `GreaterOrLessThan`."
+  }
+  validation {
+    condition     = alltrue([for _, v in var.metric_alerts : v.dynamic_criterias != null ? alltrue([for dc in v.dynamic_criterias : dc.dimension != null ? alltrue([for d in dc.dimension : contains(["Include", "Exclude", "StartsWith"], d.operator)]) : true]) : true])
+    error_message = "Invalid operator value in dynamic_criterias dimensions. Possible values are `Include`, `Exclude` and `StartsWith`."
+  }
+}
+
 variable "response_timeout_seconds" {
   type        = number
   default     = 120


### PR DESCRIPTION
## Description

- Added support for Azure Monitor Metric alerts for CDN profile as per AMBA.
- Updated interfaces example to add Azure monitor alerts as per AMBA
- Updated code to allow Tag inheritance to child resources.
- Renamed main.tf containing code for Interfaces to "main.interfaces.tf" to avoid confusion.
- Added Validation for metric_alerts variable block.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [x] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
