### PR TITLE
Remove resource group datasource and update azurerm required version …

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>= 1.13, < 3)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.71.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
 
@@ -51,8 +51,8 @@ The following resources are used by this module:
 - [azurerm_role_assignment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
 - [modtm_telemetry.telemetry](https://registry.terraform.io/providers/azure/modtm/latest/docs/resources/telemetry) (resource)
 - [random_uuid.telemetry](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) (resource)
+- [azapi_client_config.current](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/client_config) (data source)
 - [azurerm_client_config.telemetry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
-- [azurerm_resource_group.rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) (data source)
 - [modtm_module_source.telemetry](https://registry.terraform.io/providers/azure/modtm/latest/docs/data-sources/module_source) (data source)
 
 <!-- markdownlint-disable MD013 -->

--- a/avm.tflint_module.hcl
+++ b/avm.tflint_module.hcl
@@ -6,7 +6,7 @@ plugin "terraform" {
 
 plugin "avm" {
   enabled     = true
-  version     = "0.11.5"
+  version     = "0.13.0"
   source      = "github.com/Azure/tflint-ruleset-avm"
   signing_key = <<-KEY
 -----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -190,4 +190,8 @@ rule "tags" {
 
 rule "provider_modtm_version" {
   enabled = false
+}
+
+rule "valid_template_interpolation" {
+  enabled = true
 }

--- a/examples/afd_custom_domain_managed_secret/README.md
+++ b/examples/afd_custom_domain_managed_secret/README.md
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.74"
+      version = "~> 4.0"
     }
   }
 }
@@ -260,7 +260,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.74)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 ## Resources
 

--- a/examples/afd_custom_domain_managed_secret/main.tf
+++ b/examples/afd_custom_domain_managed_secret/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.74"
+      version = "~> 4.0"
     }
   }
 }

--- a/examples/afd_custom_domain_with_customer_managed_secret/README.md
+++ b/examples/afd_custom_domain_with_customer_managed_secret/README.md
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.74"
+      version = "~> 4.0"
     }
   }
 }
@@ -383,7 +383,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.74)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 ## Resources
 

--- a/examples/afd_custom_domain_with_customer_managed_secret/main.tf
+++ b/examples/afd_custom_domain_with_customer_managed_secret/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.74"
+      version = "~> 4.0"
     }
   }
 }

--- a/examples/afd_interfaces/README.md
+++ b/examples/afd_interfaces/README.md
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.103.1"
+      version = "~> 4.0"
     }
   }
 }
@@ -461,7 +461,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.103.1)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 ## Resources
 

--- a/examples/afd_interfaces/main.tf
+++ b/examples/afd_interfaces/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.103.1"
+      version = "~> 4.0"
     }
   }
 }

--- a/examples/afd_private_link_service_to_LB/README.md
+++ b/examples/afd_private_link_service_to_LB/README.md
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.74"
+      version = "~> 4.0"
     }
   }
 }
@@ -278,7 +278,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.74)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 ## Resources
 

--- a/examples/afd_private_link_service_to_LB/main.tf
+++ b/examples/afd_private_link_service_to_LB/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.74"
+      version = "~> 4.0"
     }
   }
 }

--- a/examples/afd_private_link_to_Linux_WebApp/README.md
+++ b/examples/afd_private_link_to_Linux_WebApp/README.md
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.74"
+      version = "~> 4.0"
     }
   }
 }
@@ -259,7 +259,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.74)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 ## Resources
 

--- a/examples/afd_private_link_to_Linux_WebApp/main.tf
+++ b/examples/afd_private_link_to_Linux_WebApp/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.74"
+      version = "~> 4.0"
     }
   }
 }

--- a/examples/afd_private_link_to_storage_with_caching/README.md
+++ b/examples/afd_private_link_to_storage_with_caching/README.md
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.74"
+      version = "~> 4.0"
     }
   }
 }
@@ -284,7 +284,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.74)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 ## Resources
 

--- a/examples/afd_private_link_to_storage_with_caching/main.tf
+++ b/examples/afd_private_link_to_storage_with_caching/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.74"
+      version = "~> 4.0"
     }
   }
 }

--- a/examples/afd_security_policies/README.md
+++ b/examples/afd_security_policies/README.md
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.74"
+      version = "~> 4.0"
     }
   }
 }
@@ -512,7 +512,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.74)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 ## Resources
 

--- a/examples/afd_security_policies/main.tf
+++ b/examples/afd_security_policies/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.74"
+      version = "~> 4.0"
     }
   }
 }

--- a/examples/cdn_default_microsoft_with_custom_domain/README.md
+++ b/examples/cdn_default_microsoft_with_custom_domain/README.md
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.74"
+      version = "~> 4.0"
     }
   }
 }
@@ -179,7 +179,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.74)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 ## Resources
 

--- a/examples/cdn_default_microsoft_with_custom_domain/main.tf
+++ b/examples/cdn_default_microsoft_with_custom_domain/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.74"
+      version = "~> 4.0"
     }
   }
 }

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.74"
+      version = "~> 4.0"
     }
   }
 }
@@ -359,7 +359,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.74)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 ## Resources
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.74"
+      version = "~> 4.0"
     }
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -28,8 +28,12 @@ locals {
       }
     } : {}
   }
+  resource_group_id                  = provider::azapi::subscription_resource_id(local.subscription_id, local.resource_type, local.resource_names)
+  resource_names                     = [var.resource_group_name]
+  resource_type                      = "Microsoft.Resources/resourceGroups"
   role_definition_resource_substring = "providers/Microsoft.Authorization/roleDefinitions"
   route_custom_domains = {
     for k, v in var.front_door_routes : k => [for cd in v.custom_domain_keys : azurerm_cdn_frontdoor_custom_domain.cds[cd].id]
   }
+  subscription_id = data.azapi_client_config.current.subscription_id
 }

--- a/main.cdn_frontdoor_profile.tf
+++ b/main.cdn_frontdoor_profile.tf
@@ -1,3 +1,5 @@
+data "azapi_client_config" "current" {}
+
 # using azapi since azurerm_cdn_frontdoor_profile commented above does not support identity blocks
 resource "azapi_resource" "front_door_profile" {
   type = "Microsoft.Cdn/profiles@2023-07-01-preview"
@@ -11,7 +13,7 @@ resource "azapi_resource" "front_door_profile" {
   }
   location                  = "Global"
   name                      = var.name
-  parent_id                 = data.azurerm_resource_group.rg.id
+  parent_id                 = local.resource_group_id
   schema_validation_enabled = false
   tags                      = var.tags
 

--- a/main.interfaces.tf
+++ b/main.interfaces.tf
@@ -1,7 +1,3 @@
-data "azurerm_resource_group" "rg" {
-  name = var.resource_group_name
-}
-
 # diagnostic settings can be set at profile level for front door skus and standard_microsoft cdn sku.
 resource "azurerm_monitor_diagnostic_setting" "front_door_diag" {
   for_each = strcontains(var.sku, "AzureFrontDoor") || strcontains(var.sku, "Standard_Microsoft") ? var.diagnostic_settings : {}
@@ -118,7 +114,7 @@ resource "azurerm_monitor_metric_alert" "this" {
   for_each = var.metric_alerts != null ? var.metric_alerts : {}
 
   name                     = each.value.name
-  resource_group_name      = data.azurerm_resource_group.rg.name
+  resource_group_name      = var.resource_group_name
   scopes                   = [azapi_resource.front_door_profile.id]
   auto_mitigate            = each.value.auto_mitigate
   description              = each.value.description

--- a/terraform.tf
+++ b/terraform.tf
@@ -7,7 +7,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.71.0"
+      version = "~> 4.0"
     }
     modtm = {
       source  = "azure/modtm"


### PR DESCRIPTION
…to 4.0 (#94)

* removed rg datasource

* removed test folder from example

* fixed prchecks and updated azurerm version to 4.0

## Description
Removes resource group data source and updates required azurerm version to 4.70
Fixes https://github.com/Azure/terraform-azurerm-avm-res-cdn-profile/issues/84

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [X] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [X] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
