### PR TITLE
chore: Update Terraform required_version for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Module for Azure CDN Profile (Azure Front Door and CDN)
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.3.0)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>= 1.13, < 3)
 

--- a/examples/afd_custom_domain_managed_secret/README.md
+++ b/examples/afd_custom_domain_managed_secret/README.md
@@ -5,7 +5,7 @@ This deploys the module in its simplest form.
 
 ```hcl
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -258,7 +258,7 @@ module "azurerm_cdn_frontdoor_profile" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/afd_custom_domain_managed_secret/main.tf
+++ b/examples/afd_custom_domain_managed_secret/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/afd_custom_domain_with_customer_managed_secret/README.md
+++ b/examples/afd_custom_domain_with_customer_managed_secret/README.md
@@ -5,7 +5,7 @@ This deploys the module in its simplest form.
 
 ```hcl
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -381,7 +381,7 @@ module "azurerm_cdn_frontdoor_profile" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/afd_custom_domain_with_customer_managed_secret/main.tf
+++ b/examples/afd_custom_domain_with_customer_managed_secret/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/afd_interfaces/README.md
+++ b/examples/afd_interfaces/README.md
@@ -5,7 +5,7 @@ This deploys the module in its simplest form.
 
 ```hcl
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -459,7 +459,7 @@ module "azurerm_cdn_frontdoor_profile" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/afd_interfaces/main.tf
+++ b/examples/afd_interfaces/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/afd_private_link_service_to_LB/README.md
+++ b/examples/afd_private_link_service_to_LB/README.md
@@ -5,7 +5,7 @@ This deploys the module in its simplest form.
 
 ```hcl
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -276,7 +276,7 @@ module "azurerm_cdn_frontdoor_profile" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/afd_private_link_service_to_LB/main.tf
+++ b/examples/afd_private_link_service_to_LB/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/afd_private_link_to_Linux_WebApp/README.md
+++ b/examples/afd_private_link_to_Linux_WebApp/README.md
@@ -5,7 +5,7 @@ This deploys the module in its simplest form.
 
 ```hcl
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -257,7 +257,7 @@ module "azurerm_cdn_frontdoor_profile" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/afd_private_link_to_Linux_WebApp/main.tf
+++ b/examples/afd_private_link_to_Linux_WebApp/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/afd_private_link_to_storage_with_caching/README.md
+++ b/examples/afd_private_link_to_storage_with_caching/README.md
@@ -5,7 +5,7 @@ This deploys the module in its simplest form.
 
 ```hcl
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -282,7 +282,7 @@ module "azurerm_cdn_frontdoor_profile" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/afd_private_link_to_storage_with_caching/main.tf
+++ b/examples/afd_private_link_to_storage_with_caching/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/afd_security_policies/README.md
+++ b/examples/afd_security_policies/README.md
@@ -5,7 +5,7 @@ This deploys the module in its simplest form.
 
 ```hcl
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -510,7 +510,7 @@ module "azurerm_cdn_frontdoor_profile" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/afd_security_policies/main.tf
+++ b/examples/afd_security_policies/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/cdn_default_microsoft_with_custom_domain/README.md
+++ b/examples/cdn_default_microsoft_with_custom_domain/README.md
@@ -5,7 +5,7 @@ This deploys the module in its simplest form.
 
 ```hcl
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -177,7 +177,7 @@ module "azurerm_cdn_profile" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/cdn_default_microsoft_with_custom_domain/main.tf
+++ b/examples/cdn_default_microsoft_with_custom_domain/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -5,7 +5,7 @@ This deploys the module in its simplest form.
 
 ```hcl
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -357,7 +357,7 @@ module "azurerm_cdn_frontdoor_profile" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azapi = {
       source  = "Azure/azapi"


### PR DESCRIPTION
## Description

This PR updates the Terraform `required_version` constraint to ensure consistency across all AVM modules. The constraint has been set to `>= 1.9, < 2.0` to maintain compatibility and leverage the features available in Terraform versions within this range.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g., CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!-- Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
