### PR TITLE
Making Diagnostic_settings optional for cdn_endpoints (#118)

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ map(object({
       event_hub_authorization_rule_resource_id = optional(string, null)
       event_hub_name                           = optional(string, null)
       marketplace_partner_resource_id          = optional(string, null)
-    }), {})
+    }), null)
   }))
 ```
 
@@ -679,7 +679,6 @@ Description:   Manages a map of Front Door (standard/premium) Custom Domains.
   - `host_name` - (Required) The host name of the domain. The host\_name field must be the FQDN of your domain.
   - `tls` - (Required) A tls block as defined below : -
     - `certificate_type` - (Optional) Defines the source of the SSL certificate. Possible values include 'CustomerCertificate' and 'ManagedCertificate'. Defaults to 'ManagedCertificate'.
-    - `minimum_tls_version` - (Optional) TLS protocol version that will be used for Https. Possible values include 'TLS10' and 'TLS12'. Defaults to 'TLS12'.
     - `cdn_frontdoor_secret_key` - (Optional) Key of the Front Door Secret object. This is required when certificate\_type is 'CustomerCertificate'.  
   Example Input:
 
@@ -691,7 +690,6 @@ Description:   Manages a map of Front Door (standard/premium) Custom Domains.
         host_name   = "contoso1.fabrikam.com"
         tls = {
           certificate_type    = "ManagedCertificate"
-          minimum_tls_version = "TLS12"
           cdn_frontdoor_secret_key = "Secret1_key"
         }
       }
@@ -707,7 +705,6 @@ map(object({
     host_name   = string
     tls = object({
       certificate_type         = optional(string, "ManagedCertificate")
-      minimum_tls_version      = optional(string, "TLS12") # TLS1.3 is not yet supported in Terraform azurerm_cdn_frontdoor_custom_domain
       cdn_frontdoor_secret_key = optional(string, null)
     })
   }))

--- a/examples/afd_custom_domain_managed_secret/README.md
+++ b/examples/afd_custom_domain_managed_secret/README.md
@@ -17,6 +17,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  # subscription_id = "your-subscription-id" # Replace with your Azure subscription ID
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/afd_custom_domain_managed_secret/main.tf
+++ b/examples/afd_custom_domain_managed_secret/main.tf
@@ -11,6 +11,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  # subscription_id = "your-subscription-id" # Replace with your Azure subscription ID
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/afd_custom_domain_with_customer_managed_secret/README.md
+++ b/examples/afd_custom_domain_with_customer_managed_secret/README.md
@@ -17,6 +17,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  # subscription_id = "your-subscription-id" # Replace with your Azure subscription ID
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/afd_custom_domain_with_customer_managed_secret/main.tf
+++ b/examples/afd_custom_domain_with_customer_managed_secret/main.tf
@@ -11,6 +11,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  # subscription_id = "your-subscription-id" # Replace with your Azure subscription ID
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/afd_interfaces/README.md
+++ b/examples/afd_interfaces/README.md
@@ -17,6 +17,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  # subscription_id = "your-subscription-id" # Replace with your Azure subscription ID
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/afd_interfaces/main.tf
+++ b/examples/afd_interfaces/main.tf
@@ -11,6 +11,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  # subscription_id = "your-subscription-id" # Replace with your Azure subscription ID
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/afd_private_link_service_to_LB/README.md
+++ b/examples/afd_private_link_service_to_LB/README.md
@@ -17,6 +17,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  # subscription_id = "your-subscription-id" # Replace with your Azure subscription ID
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/afd_private_link_service_to_LB/main.tf
+++ b/examples/afd_private_link_service_to_LB/main.tf
@@ -11,6 +11,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  # subscription_id = "your-subscription-id" # Replace with your Azure subscription ID
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/afd_private_link_to_Linux_WebApp/README.md
+++ b/examples/afd_private_link_to_Linux_WebApp/README.md
@@ -17,6 +17,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  # subscription_id = "your-subscription-id" # Replace with your Azure subscription ID
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/afd_private_link_to_Linux_WebApp/main.tf
+++ b/examples/afd_private_link_to_Linux_WebApp/main.tf
@@ -11,6 +11,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  # subscription_id = "your-subscription-id" # Replace with your Azure subscription ID
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/afd_private_link_to_storage_with_caching/README.md
+++ b/examples/afd_private_link_to_storage_with_caching/README.md
@@ -17,6 +17,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  # subscription_id = "your-subscription-id" # Replace with your Azure subscription ID
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/afd_private_link_to_storage_with_caching/main.tf
+++ b/examples/afd_private_link_to_storage_with_caching/main.tf
@@ -11,6 +11,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  # subscription_id = "your-subscription-id" # Replace with your Azure subscription ID
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/afd_security_policies/README.md
+++ b/examples/afd_security_policies/README.md
@@ -17,6 +17,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  # subscription_id = "your-subscription-id" # Replace with your Azure subscription ID
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/afd_security_policies/main.tf
+++ b/examples/afd_security_policies/main.tf
@@ -11,6 +11,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  # subscription_id = "your-subscription-id" # Replace with your Azure subscription ID
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/cdn_default_microsoft_with_custom_domain/README.md
+++ b/examples/cdn_default_microsoft_with_custom_domain/README.md
@@ -17,6 +17,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  # subscription_id = "your-subscription-id" # Replace with your Azure subscription ID
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/cdn_default_microsoft_with_custom_domain/main.tf
+++ b/examples/cdn_default_microsoft_with_custom_domain/main.tf
@@ -11,6 +11,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  # subscription_id = "your-subscription-id" # Replace with your Azure subscription ID
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -17,6 +17,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  # subscription_id = "your-subscription-id" # Replace with your Azure subscription ID
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -11,6 +11,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  # subscription_id = "your-subscription-id" # Replace with your Azure subscription ID
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/main.cdn_frontdoor_customdomains.tf
+++ b/main.cdn_frontdoor_customdomains.tf
@@ -9,7 +9,6 @@ resource "azurerm_cdn_frontdoor_custom_domain" "cds" {
   tls {
     cdn_frontdoor_secret_id = each.value.tls.certificate_type == "CustomerCertificate" ? azurerm_cdn_frontdoor_secret.frontdoorsecret[each.value.tls.cdn_frontdoor_secret_key].id : null
     certificate_type        = each.value.tls.certificate_type
-    minimum_tls_version     = each.value.tls.minimum_tls_version
   }
 }
 

--- a/main.interfaces.tf
+++ b/main.interfaces.tf
@@ -25,11 +25,11 @@ resource "azurerm_monitor_diagnostic_setting" "front_door_diag" {
       category_group = enabled_log.value
     }
   }
-  dynamic "metric" {
+  dynamic "enabled_metric" {
     for_each = each.value.metric_categories
 
     content {
-      category = metric.value
+      category = enabled_metric.value
     }
   }
 
@@ -41,7 +41,7 @@ resource "azurerm_monitor_diagnostic_setting" "front_door_diag" {
 }
 
 
-# cdn profile endpoints are seperate child resources that have their own diagnostic settings.
+# cdn profile endpoints are separate child resources that have their own diagnostic settings.
 resource "azurerm_monitor_diagnostic_setting" "cdn_endpoint_diag" {
   for_each = local.cdn_endpoint_diagnostics
 
@@ -68,11 +68,11 @@ resource "azurerm_monitor_diagnostic_setting" "cdn_endpoint_diag" {
       category_group = enabled_log.value
     }
   }
-  dynamic "metric" {
+  dynamic "enabled_metric" {
     for_each = each.value.diagnostic_setting.metric_categories
 
     content {
-      category = metric.value
+      category = enabled_metric.value
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -306,7 +306,7 @@ variable "cdn_endpoints" {
       event_hub_authorization_rule_resource_id = optional(string, null)
       event_hub_name                           = optional(string, null)
       marketplace_partner_resource_id          = optional(string, null)
-    }), {})
+    }), null)
   }))
   default     = {}
   description = <<DESCRIPTION
@@ -727,7 +727,6 @@ variable "front_door_custom_domains" {
     host_name   = string
     tls = object({
       certificate_type         = optional(string, "ManagedCertificate")
-      minimum_tls_version      = optional(string, "TLS12") # TLS1.3 is not yet supported in Terraform azurerm_cdn_frontdoor_custom_domain
       cdn_frontdoor_secret_key = optional(string, null)
     })
   }))
@@ -740,7 +739,6 @@ variable "front_door_custom_domains" {
   - `host_name` - (Required) The host name of the domain. The host_name field must be the FQDN of your domain.
   - `tls` - (Required) A tls block as defined below : -
     - `certificate_type` - (Optional) Defines the source of the SSL certificate. Possible values include 'CustomerCertificate' and 'ManagedCertificate'. Defaults to 'ManagedCertificate'.
-    - `minimum_tls_version` - (Optional) TLS protocol version that will be used for Https. Possible values include 'TLS10' and 'TLS12'. Defaults to 'TLS12'.
     - `cdn_frontdoor_secret_key` - (Optional) Key of the Front Door Secret object. This is required when certificate_type is 'CustomerCertificate'.
   Example Input:
 
@@ -752,7 +750,6 @@ variable "front_door_custom_domains" {
         host_name   = "contoso1.fabrikam.com"
         tls = {
           certificate_type    = "ManagedCertificate"
-          minimum_tls_version = "TLS12"
           cdn_frontdoor_secret_key = "Secret1_key"
         }
       }
@@ -764,10 +761,6 @@ variable "front_door_custom_domains" {
   validation {
     condition     = alltrue([for _, v in var.front_door_custom_domains : contains(["CustomerCertificate", "ManagedCertificate"], v.tls.certificate_type)])
     error_message = "Certificate type must be one of: 'CustomerCertificate', 'ManagedCertificate'."
-  }
-  validation {
-    condition     = alltrue([for _, v in var.front_door_custom_domains : contains(["TLS10", "TLS12"], v.tls.minimum_tls_version)])
-    error_message = "Minimum TLS version must be one of: 'TLS10', 'TLS12'."
   }
 }
 


### PR DESCRIPTION
* issue fix #107

* Pre-commit tests

## Description

- Fixed the bug identified in issue #107 by making the diagnostic_settings optional for cdn_endpoints.
- Removed option for 'minimum_tls_version' for 'front_door_custom_domains' as this is deprecated

Fixes #107 
Closes #107

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->

